### PR TITLE
Issue with long file names due to lossy type conversion in FtpServer:…

### DIFF
--- a/FtpServer.cpp
+++ b/FtpServer.cpp
@@ -1847,9 +1847,9 @@ void FtpServer::abortTransfer()
 //     0 if empty line received
 //    length of cmdLine (positive) if no empty line received 
 
-int8_t FtpServer::readChar()
+int32_t FtpServer::readChar()
 {
-  int8_t rc = -1;
+  int32_t rc = -1;
 
   if( client.available())
   {


### PR DESCRIPTION
…:readChar()